### PR TITLE
RDM-1519: Securing of accessToken cookie

### DIFF
--- a/app/oauth2/oauth2-route.js
+++ b/app/oauth2/oauth2-route.js
@@ -4,7 +4,7 @@ const COOKIE_ACCESS_TOKEN = 'accessToken';
 const oauth2Route = (req, res, next) => {
   accessTokenRequest(req)
     .then(result => {
-      res.cookie(COOKIE_ACCESS_TOKEN, result.access_token, { maxAge: result.expires_in * 1000 });
+      res.cookie(COOKIE_ACCESS_TOKEN, result.access_token, { maxAge: result.expires_in * 1000, httpOnly: true });
       res.status(204).send();
     })
     .catch(err => next(err));


### PR DESCRIPTION
Set `httpOnly` option to true, to ensure the cookie is not sent via client JavaScript, thus mitigating XSS attacks.