### PR TITLE
RDM-1742 fixed wrong URL, updated application name to match the proje…

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,13 +1,13 @@
 #!groovy
 properties(
-        [[$class: 'GithubProjectProperty', projectUrlStr: 'https://git.reform.hmcts.net/case-management/ccd-api-gateway-web'],
+        [[$class: 'GithubProjectProperty', projectUrlStr: 'https://github.com/hmcts/ccd-api-gateway'],
          pipelineTriggers([[$class: 'GitHubPushTrigger']])]
 )
 
 @Library("Infrastructure")
 
 def product = "ccd"
-def app = "api-gateway-web"
+def app = "ccd-api-gateway"
 
 withPipeline("nodejs", product, app) {
 


### PR DESCRIPTION
The git URL in Jenkins_CNP file was still referring to the old location
Also updated app name to match the new project name