### PR TITLE
RDM-1961 Make compatible for DM backend

### DIFF
--- a/app/user/auth-checker-user-only-filter.js
+++ b/app/user/auth-checker-user-only-filter.js
@@ -6,7 +6,11 @@ const authCheckerUserOnlyFilter = (req, res, next) => {
 
   userRequestAuthorizer
     .authorise(req)
-    .then(user => req.authentication.user = user)
+    .then(user => {
+      req.authentication.user = user;
+      req.headers['user-id'] = user.id;
+      req.headers['user-roles'] = user.roles.join(',');
+    })
     .then(() => next())
     .catch(error => {
       console.warn('Unsuccessful user authentication', error);

--- a/test/user/auth-checker-user-only-filter.spec.js
+++ b/test/user/auth-checker-user-only-filter.spec.js
@@ -3,7 +3,6 @@ const expect = chai.expect;
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
-const sinonExpressMock = require('sinon-express-mock');
 
 chai.use(sinonChai);
 
@@ -20,8 +19,10 @@ describe('authCheckerUserOnlyFilter', () => {
   let filter;
 
   beforeEach(() => {
-    req = sinonExpressMock.mockReq({});
-    res = sinonExpressMock.mockRes({});
+    req = {
+      headers: {}
+    };
+    res = {};
 
     userRequestAuthorizer = {
       authorise: sinon.stub()
@@ -47,6 +48,20 @@ describe('authCheckerUserOnlyFilter', () => {
     it('should set authenticated user in request', done => {
       filter(req, res, () => {
         expect(req.authentication.user).to.equal(user);
+        done();
+      });
+    });
+
+    it('should add user ID as a request header', done => {
+      filter(req, res, () => {
+        expect(req.headers['user-id']).to.equal(user.id);
+        done();
+      });
+    });
+
+    it('should add comma separated roles as a request header', done => {
+      filter(req, res, () => {
+        expect(req.headers['user-roles']).to.equal(user.roles.join(','));
         done();
       });
     });

--- a/test/user/auth-checker-user-only-filter.spec.js
+++ b/test/user/auth-checker-user-only-filter.spec.js
@@ -1,0 +1,74 @@
+const chai = require('chai');
+const expect = chai.expect;
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const sinonExpressMock = require('sinon-express-mock');
+
+chai.use(sinonChai);
+
+describe('authCheckerUserOnlyFilter', () => {
+
+  const user = {
+    id: '123',
+    roles: ['r1', 'r2']
+  };
+
+  let req;
+  let res;
+  let userRequestAuthorizer;
+  let filter;
+
+  beforeEach(() => {
+    req = sinonExpressMock.mockReq({});
+    res = sinonExpressMock.mockRes({});
+
+    userRequestAuthorizer = {
+      authorise: sinon.stub()
+    };
+
+    filter = proxyquire('../../app/user/auth-checker-user-only-filter', {
+      './user-request-authorizer': userRequestAuthorizer
+    });
+  });
+
+  describe('when user authorised', () => {
+    beforeEach(() => {
+      userRequestAuthorizer.authorise.returns(Promise.resolve(user));
+    });
+
+    it('should call next middleware without error', done => {
+      filter(req, res, error => {
+        expect(error).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should set authenticated user in request', done => {
+      filter(req, res, () => {
+        expect(req.authentication.user).to.equal(user);
+        done();
+      });
+    });
+  });
+
+  describe('when authorisation failed', () => {
+    let error;
+
+    beforeEach(() => {
+      error = {
+        status: 403
+      };
+
+      userRequestAuthorizer.authorise.returns(Promise.reject(error));
+    });
+
+    it('should call next middleware with error', done => {
+      filter(req, res, error => {
+        expect(error).to.equal(error);
+        done();
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-1961


Add `user-id` and `user-roles` headers as part of proxying to support DM backend