### PR TITLE
Fix boolean as string error

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -9,7 +9,7 @@ locals {
   default_ccd_print_service_url = "https://ccd-case-print-service-${local.env_ase_url}"
   default_cors_origin = "https://ccd-case-management-web-${local.env_ase_url}"
 
-  is_frontend = "${var.external_host_name != "" ? "true" : "false"}"
+  is_frontend = "${var.external_host_name != "" ? true : false}"
   external_host_name = "${var.external_host_name != "" ? var.external_host_name : "null"}"
 
   ccd_print_service_url = "${var.ccd_print_service_url != "" ? var.ccd_print_service_url : local.default_ccd_print_service_url}"


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Booleans as string are causing an error for `is_frontend` as it's trying to convert the value to integer.
Removed the double quotes to make them integers.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
