### PR TITLE
RDM-2187: Preparation for shutter page

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,4 +1,5 @@
 vault_section = "preprod"
+external_host_name = "gateway-ccd.aat.platform.hmcts.net"
 idam_authentication_web_url = "https://www.preprod.ccidam.reform.hmcts.net"
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
 cors_origin = "https://www-ccd.nonprod.platform.hmcts.net,http://localhost:3451,*"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-2187

### Change description ###

To implement the shutter page, an external hostname must be registered for every frontend.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```