### PR TITLE
setting s2s url to localhost for local development

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -7,7 +7,7 @@ proxy:
   case_activity: http://localhost:3460
 idam:
   base_url: http://localhost:4501
-  s2s_url: http://rpe-service-auth-provider-saat.service.core-compute-saat.internal:4502
+  s2s_url: http://localhost:4502
   service_key:
   service_name: ccd_gw
   logout_url: https://localhost:3501/login/logout


### PR DESCRIPTION
### Change description ###
setting s2s url to localhost for local development. At the moment it is configured to point to saat s2s, which creates problems when working locally with dockerised s2s service


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
