### PR TITLE
RDM-2185 - Redirect back to login page on logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following environment variables are required:
 | IDAM_USER_URL | Base URL for IdAM's User API service (idam-app). `http://localhost:4501` for the dockerised local instance or tunnelled `dev` instance. |
 | IDAM_S2S_URL | Base URL for IdAM's S2S API service (service-auth-provider). `http://localhost:4502` for the dockerised local instance or tunnelled `dev` instance. |
 | IDAM_SERVICE_KEY | API Gateway's IDAM S2S micro-service secret key. This must match the IDAM instance it's being run against. |
-| IDAM_OAUTH2_LOGOUT_ENDPOINT | URL of the IdAM OAuth2 API `logout` endpoint. `http://localhost:4501/session/${token}` for the dockerised local instance. |
+| IDAM_OAUTH2_LOGOUT_ENDPOINT | URL of the IdAM OAuth2 API `logout` endpoint. `http://localhost:4501/session/:token` for the dockerised local instance. |
 | IDAM_OAUTH2_TOKEN_ENDPOINT | URL of the IdAM OAuth2 API endpoint for obtaining an OAuth2 token. `http://localhost:4501/oauth2/token` for the dockerised local instance or tunnelled `dev` instance. |
 | IDAM_OAUTH2_CLIENT_SECRET | Secret to be passed to IdAM when obtaining an OAuth2 token. This must match the IdAM instance it's being run against. |
 | ADDRESS_LOOKUP_TOKEN | Token for use with the MoJ Address Lookup service. |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following environment variables are required:
 | IDAM_USER_URL | Base URL for IdAM's User API service (idam-app). `http://localhost:4501` for the dockerised local instance or tunnelled `dev` instance. |
 | IDAM_S2S_URL | Base URL for IdAM's S2S API service (service-auth-provider). `http://localhost:4502` for the dockerised local instance or tunnelled `dev` instance. |
 | IDAM_SERVICE_KEY | API Gateway's IDAM S2S micro-service secret key. This must match the IDAM instance it's being run against. |
-| IDAM_LOGOUT_URL | URL of the IdAM Authentication Web `logout` endpoint. `https://localhost:3501/login/logout` for the dockerised local instance. |
+| IDAM_OAUTH2_LOGOUT_ENDPOINT | URL of the IdAM OAuth2 API `logout` endpoint. `http://localhost:4501/session/${token}` for the dockerised local instance. |
 | IDAM_OAUTH2_TOKEN_ENDPOINT | URL of the IdAM OAuth2 API endpoint for obtaining an OAuth2 token. `http://localhost:4501/oauth2/token` for the dockerised local instance or tunnelled `dev` instance. |
 | IDAM_OAUTH2_CLIENT_SECRET | Secret to be passed to IdAM when obtaining an OAuth2 token. This must match the IdAM instance it's being run against. |
 | ADDRESS_LOOKUP_TOKEN | Token for use with the MoJ Address Lookup service. |

--- a/app/oauth2/logout-route.js
+++ b/app/oauth2/logout-route.js
@@ -1,12 +1,17 @@
 const config = require('config');
+const fetch = require('node-fetch');
 const COOKIE_ACCESS_TOKEN = require('./oauth2-route').COOKIE_ACCESS_TOKEN;
 
 const logoutRoute = (req, res, next) => {
-  const logoutUrl = config.get('idam.logout_url');
   const accessToken = req.cookies && req.cookies[COOKIE_ACCESS_TOKEN];
-  
+
   if (accessToken) {
-    res.redirect(`${logoutUrl}?jwt=${accessToken}`);
+    fetch(config.get('idam.oauth2.logout_endpoint').replace('${token}', accessToken), {method: 'DELETE'})
+      .then(result => {
+        res.clearCookie(COOKIE_ACCESS_TOKEN);
+        res.status(204).send();
+      })
+      .catch(err => next(err));
   } else {
     next({
       error: 'No auth token',

--- a/app/oauth2/logout-route.js
+++ b/app/oauth2/logout-route.js
@@ -1,12 +1,13 @@
 const config = require('config');
 const fetch = require('node-fetch');
 const COOKIE_ACCESS_TOKEN = require('./oauth2-route').COOKIE_ACCESS_TOKEN;
+const TOKEN_PLACEHOLDER = ':token';
 
 const logoutRoute = (req, res, next) => {
   const accessToken = req.cookies && req.cookies[COOKIE_ACCESS_TOKEN];
 
   if (accessToken) {
-    fetch(config.get('idam.oauth2.logout_endpoint').replace('${token}', accessToken), {method: 'DELETE'})
+    fetch(config.get('idam.oauth2.logout_endpoint').replace(TOKEN_PLACEHOLDER, accessToken), {method: 'DELETE'})
       .then(() => {
         res.clearCookie(COOKIE_ACCESS_TOKEN);
         res.status(204).send();

--- a/app/oauth2/logout-route.js
+++ b/app/oauth2/logout-route.js
@@ -7,7 +7,7 @@ const logoutRoute = (req, res, next) => {
 
   if (accessToken) {
     fetch(config.get('idam.oauth2.logout_endpoint').replace('${token}', accessToken), {method: 'DELETE'})
-      .then(result => {
+      .then(() => {
         res.clearCookie(COOKIE_ACCESS_TOKEN);
         res.status(204).send();
       })

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -10,9 +10,9 @@ idam:
   s2s_url: IDAM_S2S_URL
   service_key: IDAM_SERVICE_KEY
   service_name: IDAM_SERVICE_NAME
-  logout_url: IDAM_LOGOUT_URL
   oauth2:
     token_endpoint: IDAM_OAUTH2_TOKEN_ENDPOINT
+    logout_endpoint: IDAM_OAUTH2_LOGOUT_ENDPOINT
     client_id: IDAM_OAUTH2_CLIENT_ID
     client_secret: IDAM_OAUTH2_CLIENT_SECRET
 address_lookup:

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -7,10 +7,9 @@ proxy:
   case_activity: http://localhost:3460
 idam:
   base_url: http://localhost:4501
-  s2s_url: http://localhost:4502
+  s2s_url: http://rpe-service-auth-provider-saat.service.core-compute-saat.internal:4502
   service_key:
   service_name: ccd_gw
-  logout_url: https://localhost:3501/login/logout
   oauth2:
     token_endpoint: http://localhost:4501/oauth2/token
     logout_endpoint: http://localhost:4501/session/${token}

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -7,12 +7,13 @@ proxy:
   case_activity: http://localhost:3460
 idam:
   base_url: http://localhost:4501
-  s2s_url: http://rpe-service-auth-provider-saat.service.core-compute-saat.internal:4502
+  s2s_url: http://localhost:4502
   service_key:
   service_name: ccd_gw
   logout_url: https://localhost:3501/login/logout
   oauth2:
     token_endpoint: http://localhost:4501/oauth2/token
+    logout_endpoint: http://localhost:4501/session/${token}
     client_id: ccd_gateway
 address_lookup:
   detect_proxy: false

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -12,7 +12,7 @@ idam:
   service_name: ccd_gw
   oauth2:
     token_endpoint: http://localhost:4501/oauth2/token
-    logout_endpoint: http://localhost:4501/session/${token}
+    logout_endpoint: http://localhost:4501/session/:token
     client_id: ccd_gateway
 address_lookup:
   detect_proxy: false

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -46,7 +46,7 @@ module "api-gateway-web" {
     IDAM_OAUTH2_TOKEN_ENDPOINT = "${var.idam_api_url}/oauth2/token"
     IDAM_OAUTH2_CLIENT_ID = "ccd_gateway"
     IDAM_OAUTH2_CLIENT_SECRET = "${data.vault_generic_secret.oauth2_client_secret.data["value"]}"
-    IDAM_LOGOUT_URL = "${var.idam_authentication_web_url}/login/logout"
+    IDAM_OAUTH2_LOGOUT_ENDPOINT = "${var.idam_api_url}/session/${token}"
     ADDRESS_LOOKUP_TOKEN = "${data.vault_generic_secret.address_lookup_token.data["value"]}"
     CORS_ORIGIN_METHODS = "GET,POST,OPTIONS"
     CORS_ORIGIN_WHITELIST = "https://ccd-case-management-web-${local.env_ase_url},${local.cors_origin}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -46,7 +46,7 @@ module "api-gateway-web" {
     IDAM_OAUTH2_TOKEN_ENDPOINT = "${var.idam_api_url}/oauth2/token"
     IDAM_OAUTH2_CLIENT_ID = "ccd_gateway"
     IDAM_OAUTH2_CLIENT_SECRET = "${data.vault_generic_secret.oauth2_client_secret.data["value"]}"
-    IDAM_OAUTH2_LOGOUT_ENDPOINT = "${var.idam_api_url}/session/${token}"
+    IDAM_OAUTH2_LOGOUT_ENDPOINT = "${var.idam_api_url}/session/$${token}"
     ADDRESS_LOOKUP_TOKEN = "${data.vault_generic_secret.address_lookup_token.data["value"]}"
     CORS_ORIGIN_METHODS = "GET,POST,OPTIONS"
     CORS_ORIGIN_WHITELIST = "https://ccd-case-management-web-${local.env_ase_url},${local.cors_origin}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -46,7 +46,7 @@ module "api-gateway-web" {
     IDAM_OAUTH2_TOKEN_ENDPOINT = "${var.idam_api_url}/oauth2/token"
     IDAM_OAUTH2_CLIENT_ID = "ccd_gateway"
     IDAM_OAUTH2_CLIENT_SECRET = "${data.vault_generic_secret.oauth2_client_secret.data["value"]}"
-    IDAM_OAUTH2_LOGOUT_ENDPOINT = "${var.idam_api_url}/session/$${token}"
+    IDAM_OAUTH2_LOGOUT_ENDPOINT = "${var.idam_api_url}/session/:token"
     ADDRESS_LOOKUP_TOKEN = "${data.vault_generic_secret.address_lookup_token.data["value"]}"
     CORS_ORIGIN_METHODS = "GET,POST,OPTIONS"
     CORS_ORIGIN_WHITELIST = "https://ccd-case-management-web-${local.env_ase_url},${local.cors_origin}"

--- a/test/oauth2/logout-route.spec.js
+++ b/test/oauth2/logout-route.spec.js
@@ -10,7 +10,7 @@ chai.use(sinonChai);
 
 describe('logoutRoute', () => {
   const ACCESS_TOKEN = 'eycdjc7hf3478g4f37';
-  const LOGOUT_URL = 'http://localhost/session/${token}';
+  const LOGOUT_END_POINT = 'http://localhost/session/${token}';
 
   let request;
   let response;
@@ -23,7 +23,7 @@ describe('logoutRoute', () => {
     config = {
       get: sinon.stub()
     };
-    config.get.withArgs('idam.oauth2.logout_endpoint').returns(LOGOUT_URL);
+    config.get.withArgs('idam.oauth2.logout_endpoint').returns(LOGOUT_END_POINT);
 
     request = sinonExpressMock.mockReq({
       cookies: {
@@ -33,7 +33,7 @@ describe('logoutRoute', () => {
     response = sinonExpressMock.mockRes();
     next = sinon.stub();
 
-    fetch = fetchMock.sandbox().delete(LOGOUT_URL.replace('${token}', ACCESS_TOKEN), {});
+    fetch = fetchMock.sandbox().delete(LOGOUT_END_POINT.replace('${token}', ACCESS_TOKEN), {});
 
     logoutRoute = proxyquire('../../app/oauth2/logout-route', {
       'config': config,
@@ -44,7 +44,7 @@ describe('logoutRoute', () => {
   it('should call IDAM OAuth 2 logout endpoint with JWT token', done => {
     response.status.callsFake(() => {
       try {
-        expect(fetch.called(LOGOUT_URL.replace('${token}', ACCESS_TOKEN))).to.be.true;
+        expect(fetch.called(LOGOUT_END_POINT.replace('${token}', ACCESS_TOKEN))).to.be.true;
         expect(next).not.to.be.called;
         expect(response.clearCookie).to.be.calledWith(COOKIE_ACCESS_TOKEN);
         expect(response.status).to.be.calledWith(204);

--- a/test/oauth2/logout-route.spec.js
+++ b/test/oauth2/logout-route.spec.js
@@ -10,7 +10,7 @@ chai.use(sinonChai);
 
 describe('logoutRoute', () => {
   const ACCESS_TOKEN = 'eycdjc7hf3478g4f37';
-  const LOGOUT_END_POINT = 'http://localhost/session/${token}';
+  const LOGOUT_END_POINT = 'http://localhost/session/:token';
 
   let request;
   let response;
@@ -33,7 +33,7 @@ describe('logoutRoute', () => {
     response = sinonExpressMock.mockRes();
     next = sinon.stub();
 
-    fetch = fetchMock.sandbox().delete(LOGOUT_END_POINT.replace('${token}', ACCESS_TOKEN), {});
+    fetch = fetchMock.sandbox().delete(LOGOUT_END_POINT.replace(':token', ACCESS_TOKEN), {});
 
     logoutRoute = proxyquire('../../app/oauth2/logout-route', {
       'config': config,
@@ -44,7 +44,7 @@ describe('logoutRoute', () => {
   it('should call IDAM OAuth 2 logout endpoint with JWT token', done => {
     response.status.callsFake(() => {
       try {
-        expect(fetch.called(LOGOUT_END_POINT.replace('${token}', ACCESS_TOKEN))).to.be.true;
+        expect(fetch.called(LOGOUT_END_POINT.replace(':token', ACCESS_TOKEN))).to.be.true;
         expect(next).not.to.be.called;
         expect(response.clearCookie).to.be.calledWith(COOKIE_ACCESS_TOKEN);
         expect(response.status).to.be.calledWith(204);

--- a/test/oauth2/logout-route.spec.js
+++ b/test/oauth2/logout-route.spec.js
@@ -1,5 +1,6 @@
 const chai = require('chai');
 const expect = chai.expect;
+const fetchMock = require('fetch-mock');
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
@@ -9,39 +10,51 @@ chai.use(sinonChai);
 
 describe('logoutRoute', () => {
   const ACCESS_TOKEN = 'eycdjc7hf3478g4f37';
-  const LOGOUT_URL = 'http://idam.reform.hmcts.net/login/logout';
+  const LOGOUT_URL = 'http://localhost/session/${token}';
 
   let request;
   let response;
   let next;
   let config;
   let logoutRoute;
+  let fetch;
 
   beforeEach(() => {
     config = {
       get: sinon.stub()
     };
-    config.get.withArgs('idam.logout_url').returns(LOGOUT_URL);
+    config.get.withArgs('idam.oauth2.logout_endpoint').returns(LOGOUT_URL);
 
     request = sinonExpressMock.mockReq({
       cookies: {
         [COOKIE_ACCESS_TOKEN]: ACCESS_TOKEN
       }
     });
-    response = sinonExpressMock.mockRes({});
+    response = sinonExpressMock.mockRes();
     next = sinon.stub();
 
+    fetch = fetchMock.sandbox().delete(LOGOUT_URL.replace('${token}', ACCESS_TOKEN), {});
 
     logoutRoute = proxyquire('../../app/oauth2/logout-route', {
-      'config': config
+      'config': config,
+      'node-fetch': fetch
     }).logoutRoute;
   });
 
-  it('should redirect to logout URL with JWT token', () => {
-    logoutRoute(request, response, next);
+  it('should call IDAM OAuth 2 logout endpoint with JWT token', done => {
+    response.status.callsFake(() => {
+      try {
+        expect(fetch.called(LOGOUT_URL.replace('${token}', ACCESS_TOKEN))).to.be.true;
+        expect(next).not.to.be.called;
+        expect(response.clearCookie).to.be.calledWith(COOKIE_ACCESS_TOKEN);
+        expect(response.status).to.be.calledWith(204);
+        done();
+      } catch (e) {
+        done(e);
+      }
+    });
 
-    expect(response.redirect).to.be.calledWith(`${LOGOUT_URL}?jwt=${ACCESS_TOKEN}`);
-    expect(next).not.to.be.called;
+    logoutRoute(request, response, next);
   });
 
   it('should return 400 error when cookies missing', () => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-2185

### Change description ###
The logout route on the gateway used to redirect the user to the IDAM logout page, this is now changed to call IDAM API directly to delete (revoke) the user's access token and return response to clear the access token cookie. Please also review the changes made to yaml and tf file (so it doesn't break higher environments). 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
