### PR TITLE
RDM-2185 - Redirect back to login page on logout - SIDAM api call fix

### DIFF
--- a/app/oauth2/logout-route.js
+++ b/app/oauth2/logout-route.js
@@ -7,7 +7,16 @@ const logoutRoute = (req, res, next) => {
   const accessToken = req.cookies && req.cookies[COOKIE_ACCESS_TOKEN];
 
   if (accessToken) {
-    fetch(config.get('idam.oauth2.logout_endpoint').replace(TOKEN_PLACEHOLDER, accessToken), {method: 'DELETE'})
+    const options = {
+      method: 'DELETE',
+      headers: {
+        'Authorization': 'Basic '
+        + Buffer.from(config.get('idam.oauth2.client_id') + ':' + config.get('idam.oauth2.client_secret'))
+          .toString('base64'),
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
+    };
+    fetch(config.get('idam.oauth2.logout_endpoint').replace(TOKEN_PLACEHOLDER, accessToken), options)
       .then(() => {
         res.clearCookie(COOKIE_ACCESS_TOKEN);
         res.status(204).send();

--- a/test/oauth2/logout-route.spec.js
+++ b/test/oauth2/logout-route.spec.js
@@ -5,10 +5,12 @@ const proxyquire = require('proxyquire');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const sinonExpressMock = require('sinon-express-mock');
-const COOKIE_ACCESS_TOKEN = require('../../app/oauth2/oauth2-route').COOKIE_ACCESS_TOKEN;
+const ACCESS_TOKEN_COOKIE_NAME = require('../../app/oauth2/oauth2-route').COOKIE_ACCESS_TOKEN;
 chai.use(sinonChai);
 
 describe('logoutRoute', () => {
+  const CLIENT_ID = 'ccd_gateway';
+  const CLIENT_SECRET = 'abc123def456';
   const ACCESS_TOKEN = 'eycdjc7hf3478g4f37';
   const LOGOUT_END_POINT = 'http://localhost/session/:token';
 
@@ -23,11 +25,13 @@ describe('logoutRoute', () => {
     config = {
       get: sinon.stub()
     };
+    config.get.withArgs('idam.oauth2.client_id').returns(CLIENT_ID);
+    config.get.withArgs('idam.oauth2.client_secret').returns(CLIENT_SECRET);
     config.get.withArgs('idam.oauth2.logout_endpoint').returns(LOGOUT_END_POINT);
 
     request = sinonExpressMock.mockReq({
       cookies: {
-        [COOKIE_ACCESS_TOKEN]: ACCESS_TOKEN
+        [ACCESS_TOKEN_COOKIE_NAME]: ACCESS_TOKEN
       }
     });
     response = sinonExpressMock.mockRes();
@@ -45,8 +49,9 @@ describe('logoutRoute', () => {
     response.status.callsFake(() => {
       try {
         expect(fetch.called(LOGOUT_END_POINT.replace(':token', ACCESS_TOKEN))).to.be.true;
+        expect(fetch.lastOptions().headers['Authorization']).to.equal('Basic ' + Buffer.from(CLIENT_ID + ':' + CLIENT_SECRET).toString('base64'));
         expect(next).not.to.be.called;
-        expect(response.clearCookie).to.be.calledWith(COOKIE_ACCESS_TOKEN);
+        expect(response.clearCookie).to.be.calledWith(ACCESS_TOKEN_COOKIE_NAME);
         expect(response.status).to.be.calledWith(204);
         done();
       } catch (e) {
@@ -55,6 +60,10 @@ describe('logoutRoute', () => {
     });
 
     logoutRoute(request, response, next);
+
+    expect(config.get).to.be.calledWith('idam.oauth2.client_id');
+    expect(config.get).to.be.calledWith('idam.oauth2.client_secret');
+    expect(config.get).to.be.calledWith('idam.oauth2.logout_endpoint');
   });
 
   it('should return 400 error when cookies missing', () => {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-2185


### Change description ###
Fixed SIDAM logout API call from gateway by passing authorisation header. Works on IDAM too.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
