### PR TITLE
Correct configuration for accessing external services

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -3,14 +3,18 @@ provider "vault" {
 }
 
 locals {
-  app_full_name = "${var.product}-${var.component}"
-  env_ase_url = "${var.env}.service.${data.terraform_remote_state.core_apps_compute.ase_name[0]}.internal"
-
-  default_cors_origin = "https://ccd-case-management-web-${local.env_ase_url}"
-  default_document_management_url = "http://dm-store-${local.env_ase_url}"
-
   is_frontend = "${var.external_host_name != "" ? "1" : "0"}"
   external_host_name = "${var.external_host_name != "" ? var.external_host_name : "null"}"
+
+  ase_name = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
+
+  local_env = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "aat" : "saat" : var.env}"
+  local_ase = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "core-compute-aat" : "core-compute-saat" : local.ase_name}"
+
+  env_ase_url = "${local.local_env}.service.${local.local_ase}.internal"
+
+  default_cors_origin = "https://ccd-case-management-web-${var.env}.service.${local.ase_name}.internal"
+  default_document_management_url = "http://dm-store-${local.env_ase_url}"
 
   cors_origin = "${var.cors_origin != "" ? var.cors_origin : local.default_cors_origin}"
   ccd_print_service_url = "http://ccd-case-print-service-${local.env_ase_url}"
@@ -34,7 +38,7 @@ data "vault_generic_secret" "idam_service_key" {
 
 module "api-gateway-web" {
   source = "git@github.com:hmcts/moj-module-webapp?ref=master"
-  product = "${local.app_full_name}"
+  product = "${var.product}-${var.component}"
   location = "${var.location}"
   env = "${var.env}"
   ilbIp = "${var.ilbIp}"
@@ -49,7 +53,7 @@ module "api-gateway-web" {
     IDAM_OAUTH2_LOGOUT_ENDPOINT = "${var.idam_api_url}/session/:token"
     ADDRESS_LOOKUP_TOKEN = "${data.vault_generic_secret.address_lookup_token.data["value"]}"
     CORS_ORIGIN_METHODS = "GET,POST,OPTIONS"
-    CORS_ORIGIN_WHITELIST = "https://ccd-case-management-web-${local.env_ase_url},${local.cors_origin}"
+    CORS_ORIGIN_WHITELIST = "${local.default_cors_origin},${local.cors_origin}"
     IDAM_BASE_URL = "${var.idam_api_url}"
     IDAM_S2S_URL = "${local.s2s_url}"
     IDAM_SERVICE_KEY = "${data.vault_generic_secret.idam_service_key.data["value"]}"

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -1,4 +1,3 @@
 vault_section = "preprod"
 idam_api_url = "https://preprod-idamapi.reform.hmcts.net:3511"
-s2s_url = "https://preprod-s2s-api.reform.hmcts.net:3511"
 authentication_web_url = "https://idam.preprod.ccidam.reform.hmcts.net"


### PR DESCRIPTION
Configure API Gateway to access services in AAT when deployed to a `preview` environment, and ones in SAAT when deployed to an `spreview` environment.

### JIRA link (if applicable) ###
None.

### Change description ###
Configure API Gateway to access services in AAT when deployed to a `preview` environment, and ones in SAAT when deployed to an `spreview` environment. Also includes a correction for S2S authentication URL when in a `preview` environment, and amendment of `CORS_ORIGIN_WHITELIST`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
