### PR TITLE
Force use of HTTPS

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -45,6 +45,7 @@ module "api-gateway-web" {
   subscription = "${var.subscription}"
   is_frontend = "${local.is_frontend}"
   additional_host_name = "${local.external_host_name}"
+  https_only = "${var.https_only}"
 
   app_settings = {
     IDAM_OAUTH2_TOKEN_ENDPOINT = "${var.idam_api_url}/oauth2/token"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -49,3 +49,7 @@ variable "cors_origin" {
 variable "document_management_url" {
   default = ""
 }
+
+variable "https_only" {
+  default = "true"
+}


### PR DESCRIPTION
Use the webapp http_only switch to force exposed apps to only use HTTPS.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-2367

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
