### PR TITLE
RDM-2529: Use @hmcts/nodejs-logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,9 +4,9 @@ enableAppInsights();
 
 let express = require('express');
 let cookieParser = require('cookie-parser');
-let logger = require('morgan');
 let proxy = require('http-proxy-middleware');
 const config = require('config');
+const { Express: ExpressLogger, Logger } = require('@hmcts/nodejs-logging');
 const authCheckerUserOnlyFilter = require('./app/user/auth-checker-user-only-filter');
 const addressLookup = require('./app/address/address-lookup');
 const serviceFilter = require('./app/service/service-filter');
@@ -16,8 +16,9 @@ const oauth2Route = require('./app/oauth2/oauth2-route').oauth2Route;
 const logoutRoute = require('./app/oauth2/logout-route').logoutRoute;
 
 let app = express();
+const logger = Logger.getLogger('app');
 
-app.use(logger('dev'));
+app.use(ExpressLogger.accessLogger());
 app.use(cookieParser());
 
 const applyProxy = (app, config) => {
@@ -105,6 +106,8 @@ app.use(function (req, res, next) {
 
 // error handler
 app.use(function (err, req, res, next) { // eslint-disable-line no-unused-vars
+  logger.error(err);
+
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};

--- a/app/address/address-lookup.js
+++ b/app/address/address-lookup.js
@@ -2,6 +2,9 @@ const config = require('config');
 const extractAddress = require('./extract-address');
 const fetch = require('node-fetch');
 const HttpsProxyAgent = require('https-proxy-agent');
+const { Logger } = require('@hmcts/nodejs-logging');
+
+const logger = Logger.getLogger('addressLookup');
 
 function addressLookup(postcode) {
 
@@ -12,7 +15,7 @@ function addressLookup(postcode) {
     .then(processBody)
     .catch((e) => {
       if (e.logMessage) {
-        console.error(e.logMessage + ', ErrorId=' + e.error);
+        logger.error(e.logMessage, 'ErrorId=', e.error);
       }
       throw e;
     });

--- a/app/oauth2/access-token-request.js
+++ b/app/oauth2/access-token-request.js
@@ -1,6 +1,9 @@
 const config = require('config');
 const fetch = require('node-fetch');
 const url = require('url');
+const { Logger } = require('@hmcts/nodejs-logging');
+
+const logger = Logger.getLogger('accessTokenRequest');
 
 const completeRedirectURI = (uri) => {
   if (!uri.startsWith('http')) {
@@ -28,7 +31,7 @@ function accessTokenRequest(request) {
     .then(response => response.status === 200 ? response : response.text().then(text => Promise.reject(new Error(text))))
     .then(response => response.json())
     .catch(error => {
-      console.error('Failed to obtain access token:', error);
+      logger.error('Failed to obtain access token:', error);
       throw error;
     });
 }

--- a/app/service/service-filter.js
+++ b/app/service/service-filter.js
@@ -1,4 +1,7 @@
 const serviceTokenGenerator = require('./service-token-generator');
+const { Logger } = require('@hmcts/nodejs-logging');
+
+const logger = Logger.getLogger('serviceFilter');
 
 const serviceFilter = (req, res, next) => {
     serviceTokenGenerator()
@@ -8,14 +11,14 @@ const serviceFilter = (req, res, next) => {
         })
         .catch(error => {
           if (error.name === 'FetchError') {
-              console.error(error);
+              logger.error(error);
               next({
                 status: 500,
                 error: 'Internal Server Error',
                 message: error.message
               });
           } else {
-              console.warn('Unsuccessful S2S authentication', error);
+              logger.warn('Unsuccessful S2S authentication', error);
               next({
                   status: error.status || 401
               });

--- a/app/user/auth-checker-user-only-filter.js
+++ b/app/user/auth-checker-user-only-filter.js
@@ -1,4 +1,7 @@
 const userRequestAuthorizer = require('./user-request-authorizer');
+const { Logger } = require('@hmcts/nodejs-logging');
+
+const logger = Logger.getLogger('authCheckerUserOnlyFilter');
 
 const authCheckerUserOnlyFilter = (req, res, next) => {
 
@@ -14,14 +17,14 @@ const authCheckerUserOnlyFilter = (req, res, next) => {
     .then(() => next())
     .catch(error => {
       if (error.name === 'FetchError') {
-        console.error(error);
+        logger.error(error);
         next({
           status: 500,
           error: 'Internal Server Error',
           message: error.message
         });
       } else {
-        console.warn('Unsuccessful user authentication', error);
+        logger.warn('Unsuccessful user authentication', error);
         error.status = error.status || 401;
         next(error);
       }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@hmcts/nodejs-healthcheck": "^1.4.5",
+    "@hmcts/nodejs-logging": "^3.0.0",
     "applicationinsights": "^1.0.2",
     "body-parser": "^1.18.2",
     "config": "^1.29.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "https-proxy-agent": "^2.1.1",
     "js-yaml": "^3.8.4",
     "jwt-decode": "^2.2.0",
-    "morgan": "^1.9.0",
     "node-fetch": "^1.7.0",
     "otp": "^0.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,14 @@
     js-yaml "^3.8.4"
     superagent "^3.5.1"
 
+"@hmcts/nodejs-logging@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@hmcts/nodejs-logging/-/nodejs-logging-3.0.0.tgz#81d84cea5528fa57b4162641b427233fca771715"
+  dependencies:
+    moment "^2.19.3"
+    on-finished "^2.3.0"
+    winston "^2.4.1"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -170,6 +178,10 @@ async@^2.1.4, async@^2.2.0:
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
     lodash "^4.14.0"
+
+async@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
 
 async@~2.1.5:
   version "2.1.5"
@@ -424,6 +436,10 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
+colors@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+
 colors@^1.1.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.1.tgz#f4a3d302976aaf042356ba1ade3b1a2c62d9d794"
@@ -534,6 +550,10 @@ cryptiles@3.x.x:
 cvss@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cvss/-/cvss-1.0.2.tgz#df67e92bf12a796f49e928799c8db3ba74b9fcd6"
+
+cycle@1.0.x:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
 
 d@1:
   version "1.0.0"
@@ -955,6 +975,10 @@ extsprintf@1.3.0:
 extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+
+eyes@0.1.x:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"
@@ -1592,7 +1616,7 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isstream@~0.1.2:
+isstream@0.1.x, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
@@ -1987,6 +2011,10 @@ module-not-found-error@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
 
+moment@^2.19.3:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.2.tgz#3c257f9839fc0e93ff53149632239eb90783ff66"
+
 moment@^2.22.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.1.tgz#529a2e9bf973f259c9643d237fda84de3a26e8ad"
@@ -2126,7 +2154,7 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
-on-finished@~2.3.0:
+on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
@@ -2786,6 +2814,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+
 "statuses@>= 1.3.1 < 2", statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
@@ -3053,6 +3085,17 @@ which@^1.1.1, which@^1.2.10, which@^1.2.9:
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
+
+winston@^2.4.1:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.3.tgz#7a9fdab371b6d3d9b63a592947846d856948c517"
+  dependencies:
+    async "~1.0.0"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    stack-trace "0.0.x"
 
 wordwrap@0.0.2:
   version "0.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -217,12 +217,6 @@ base64url@2.0.0, base64url@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-2.0.0.tgz#eac16e03ea1438eff9423d69baa36262ed1f70bb"
 
-basic-auth@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.0.tgz#015db3f353e02e56377755f962742e8981e7bbba"
-  dependencies:
-    safe-buffer "5.1.1"
-
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -2019,16 +2013,6 @@ moment@^2.22.1:
   version "2.22.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.22.1.tgz#529a2e9bf973f259c9643d237fda84de3a26e8ad"
 
-morgan@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.0.tgz#d01fa6c65859b76fcf31b3cb53a3821a311d8051"
-  dependencies:
-    basic-auth "~2.0.0"
-    debug "2.6.9"
-    depd "~1.1.1"
-    on-finished "~2.3.0"
-    on-headers "~1.0.1"
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -2159,10 +2143,6 @@ on-finished@^2.3.0, on-finished@~2.3.0:
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"
   dependencies:
     ee-first "1.1.1"
-
-on-headers@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
 once@1.x, once@^1.3.0, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-2529

### Change description ###

Replace `morgan` (access login) and `console` (errors/warnings) by logger provided by `@hmcts/nodejs-logging`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```