### PR TITLE
Lock nodejs to version 8.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.0
+FROM node:8-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "ccd-api-gateway-web",
   "version": "1.4.0",
   "private": true,
+  "engines": {
+    "node": "^8.9.4"
+  },
   "scripts": {
     "start": "cross-env NODE_PATH=. node server.js",
     "setup": "cross-env NODE_PATH=. node --version",


### PR DESCRIPTION
Rationale:
- WebApps default available is 8.9.4 but 8.11.1 is available, so keep up
  with what is available on Azure
- Docker based images are always the latest on the 8.x branch, with
  nothing earlier.




https://tools.hmcts.net/jira/browse/RDM-3073





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```