### PR TITLE
Use 8.12.0-slim instead of 8-alpine images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY package.json yarn.lock /usr/src/app/
-RUN yarn install
+RUN yarn install --production
 
 COPY app.js server.js /usr/src/app/
 COPY app /usr/src/app/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:8.12.0-slim
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
"due to an issue with Kubernetes DNS, please use debian slim-based Node
images for your front-end Docker images (e.g. `node:8.12.0-slim,
node:10.11.0-slim`)" ... timw

Also lock our images to a specific Node version instead of an open
version.



https://tools.hmcts.net/jira/browse/RDM-3128





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```