### PR TITLE
RDM-3684: Disable https_only

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -47,7 +47,7 @@ variable "document_management_url" {
 }
 
 variable "https_only" {
-  default = "true"
+  default = "false"
 }
 
 variable "common_tags" {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-3684

### Change description ###

Palo Alto only works over HTTP, https must be disabled between AppGW and
AppService

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```