### PR TITLE
Add stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 28
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: false
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - dependencies
+
+# Label to use when marking an issue as stale
+staleLabel: stale
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue is being closed automatically as it was stale


### PR DESCRIPTION
Which ensures:
- PRs go stale after 4 weeks (two sprints)
- We don't close automatically for now
- We mark stale with label 'stale'
- security, dependency and pinned labels will block any effort to make
  something stale



https://tools.hmcts.net/jira/browse/RDM-3840





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```