### PR TITLE
Use ACR cache optimisation in pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,6 @@
 !app/**
 !bin/**
 !config/**
+
+!acb.yaml
+!Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,20 @@
-FROM node:8.12.0-slim
-
-WORKDIR /usr/src/app
+# Base image
+FROM hmcts.azurecr.io/hmcts/base/node/stretch-slim-lts-8 as base
 
 COPY package.json yarn.lock ./
-RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s \
-    && export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH" \
-    && yarn install --production \
+RUN yarn install --production \
     && yarn cache clean
-
 
 COPY app.js server.js ./
 COPY app ./app
 COPY config ./config
 
+# Runtime image
+FROM base as runtime
 ENV PORT 3453
-
 HEALTHCHECK --interval=10s \
     --timeout=10s \
     --retries=10 \
     CMD http_proxy="" curl --silent --fail http://localhost:3453/health
-
 EXPOSE 3453
-CMD [ "yarn", "start" ]
+USER hmcts

--- a/acb.tpl.yaml
+++ b/acb.tpl.yaml
@@ -1,0 +1,33 @@
+version: 1.0-preview-1
+steps:
+  - id: pull-base
+    cmd: docker pull {{.Run.Registry}}/hmcts/ccd-api-gateway/base:latest || true
+    when: ["-"]
+    keep: true
+
+  - id: base
+    build: >
+      -t {{.Run.Registry}}/hmcts/ccd-api-gateway/base
+      --cache-from {{.Run.Registry}}/hmcts/ccd-api-gateway/base:latest
+      --target base
+      .
+    when:
+      - pull-base
+    keep: true
+
+  - id: runtime
+    build: >
+      -t {{.Run.Registry}}/{{CI_IMAGE_TAG}}
+      --cache-from {{.Run.Registry}}/hmcts/ccd-api-gateway/base:latest
+      --target runtime
+      .
+    when:
+      - base
+    keep: true
+
+  - id: push-images
+    push:
+      - "{{.Run.Registry}}/hmcts/ccd-api-gateway/base:latest"
+      - "{{.Run.Registry}}/{{CI_IMAGE_TAG}}"
+    when:
+      - runtime


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CNP-1131

### Change description ###

This PR leverages on layers re-use to reduce the the docker image build time in CI:
the image build time changes from 1:30 min to 45 seconds for this project, ~half the time, if the npm dependencies do not change.

It also introduces [base nodeJS images](https://github.com/hmcts/cnp-node-base) as well as the `hmcts` user, added for security compliance.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
