### PR TITLE
Force https_only on gateway

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -47,7 +47,7 @@ variable "document_management_url" {
 }
 
 variable "https_only" {
-  default = "false"
+  default = "true"
 }
 
 variable "common_tags" {


### PR DESCRIPTION
Seems some misunderstanding, we want https_only and then allow the GW
to manage redirects over http to Palo Alto.



### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-4243


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```