### PR TITLE
Bumping version to publish chart

### DIFF
--- a/charts/ccd-api-gateway-web/Chart.yaml
+++ b/charts/ccd-api-gateway-web/Chart.yaml
@@ -1,7 +1,7 @@
 description: Helm chart for the HMCTS CCD API Gateway
 name: ccd-api-gateway-web
 home: https://github.com/hmcts/ccd-api-gateway
-version: 0.0.3
+version: 0.0.4
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET


### PR DESCRIPTION
Bumping version to publish chart after removing releasenameoverride

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-1005

### Change description ###

Bumping version to publish chart after removing releasenameoverride

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
