### PR TITLE
RDM-4572 - Configure max request content length

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ The following environment variables are required:
 | CORS_ORIGIN_WHITELIST | Comma-separated list of authorised origins for Cross-Origin requests. `http://localhost:3451,http://localhost:3452` for the local instances of CCD |
 | APPINSIGHTS_INSTRUMENTATIONKEY | Secret for Microsoft Insights logging, can be a dummy string in local. |
 
+**Note:** To support large document uploads via the api gateway, the maximum allowed length for request content is 
+configured via *maxAllowedContentLength* property for request filter in **web.config** (config file within source repository). 
+
 ### Install dependencies
 
 The project uses [yarn](https://yarnpkg.com/).

--- a/web.config
+++ b/web.config
@@ -42,6 +42,8 @@
                 <hiddenSegments>
                     <remove segment="bin"/>
                 </hiddenSegments>
+                <!-- file upload limit 100MB  -->
+                <requestLimits maxAllowedContentLength="104857600" />
             </requestFiltering>
         </security>
 

--- a/web.config
+++ b/web.config
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     This configuration file is required if iisnode is used to run node processes behind
+     IIS or IIS Express.  For more information, visit:
+
+     https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/web.config
+-->
+
+<configuration>
+    <system.webServer>
+        <!-- Visit http://blogs.msdn.com/b/windowsazure/archive/2013/11/14/introduction-to-websockets-on-windows-azure-web-sites.aspx for more information on WebSocket support -->
+        <webSocket enabled="false" />
+        <handlers>
+            <!-- Indicates that the server.js file is a node.js site to be handled by the iisnode module -->
+            <add name="iisnode" path="server.js" verb="*" modules="iisnode"/>
+        </handlers>
+        <rewrite>
+            <rules>
+                <!-- Do not interfere with requests for node-inspector debugging -->
+                <rule name="NodeInspector" patternSyntax="ECMAScript" stopProcessing="true">
+                    <match url="^server.js\/debug[\/]?" />
+                </rule>
+
+                <!-- First we consider whether the incoming URL matches a physical file in the /public folder -->
+                <rule name="StaticContent">
+                    <action type="Rewrite" url="public{PATH_INFO}"/>
+                </rule>
+
+                <!-- All other URLs are mapped to the node.js site entry point -->
+                <rule name="DynamicContent">
+                    <conditions>
+                        <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="True"/>
+                    </conditions>
+                    <action type="Rewrite" url="server.js"/>
+                </rule>
+            </rules>
+        </rewrite>
+
+        <!-- 'bin' directory has no special meaning in node.js and apps can be placed in it -->
+        <security>
+            <requestFiltering>
+                <hiddenSegments>
+                    <remove segment="bin"/>
+                </hiddenSegments>
+            </requestFiltering>
+        </security>
+
+        <!-- Make sure error responses are left untouched -->
+        <httpErrors existingResponse="PassThrough" />
+
+        <!--
+          You can control how Node is hosted within IIS using the following options:
+            * watchedFiles: semi-colon separated list of files that will be watched for changes to restart the server
+            * node_env: will be propagated to node as NODE_ENV environment variable
+            * debuggingEnabled - controls whether the built-in debugger is enabled
+
+          See https://github.com/tjanczuk/iisnode/blob/master/src/samples/configuration/web.config for a full list of options
+        -->
+        <!--<iisnode watchedFiles="web.config;*.js"/>-->
+    </system.webServer>
+</configuration>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-4572


### Change description ###
IIS web server by default allows max request content length to be 30000000 bytes (28.6 MB). 
https://docs.microsoft.com/en-us/iis/configuration/system.webserver/security/requestfiltering/requestlimits/
This PR is to override the default value for the request filter.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
