### PR TITLE
Bumping chart version to publish

### DIFF
--- a/charts/ccd-api-gateway-web/Chart.yaml
+++ b/charts/ccd-api-gateway-web/Chart.yaml
@@ -1,7 +1,7 @@
 description: Helm chart for the HMCTS CCD API Gateway
 name: ccd-api-gateway-web
 home: https://github.com/hmcts/ccd-api-gateway
-version: 0.0.4
+version: 0.0.5
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET


### PR DESCRIPTION
Current published chart is broken on AAT AKS cluster .

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
