### PR TITLE
Upgrade base chart for hmcts demo

### DIFF
--- a/charts/ccd-api-gateway-web/Chart.yaml
+++ b/charts/ccd-api-gateway-web/Chart.yaml
@@ -1,7 +1,7 @@
 description: Helm chart for the HMCTS CCD API Gateway
 name: ccd-api-gateway-web
 home: https://github.com/hmcts/ccd-api-gateway
-version: 1.0.1
+version: 1.0.2
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-api-gateway-web/requirements.yaml
+++ b/charts/ccd-api-gateway-web/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: nodejs
-    version: ~1.6.0
+    version: ~1.8.0
     repository: '@hmctspublic'

--- a/charts/ccd-api-gateway-web/values.aat.template.yaml
+++ b/charts/ccd-api-gateway-web/values.aat.template.yaml
@@ -1,17 +1,4 @@
 nodejs:
-  environment:
-    #IDAM_OAUTH2_TOKEN_ENDPOINT: https://preprod-idamapi.reform.hmcts.net:3511/oauth2/token
-    IDAM_OAUTH2_TOKEN_ENDPOINT: https://idam-api.aat.platform.hmcts.net/oauth2/token
-    #IDAM_OAUTH2_LOGOUT_ENDPOINT: https://preprod-idamapi.reform.hmcts.net:3511/session/:token
-    IDAM_OAUTH2_LOGOUT_ENDPOINT: https://idam-api.aat.platform.hmcts.net/session/:token
-    #IDAM_BASE_URL: https://preprod-idamapi.reform.hmcts.net:3511
-    IDAM_BASE_URL: https://idam-api.aat.platform.hmcts.net
-    IDAM_S2S_URL: http://rpe-service-auth-provider-aat.service.core-compute-aat.internal
-    CORS_ORIGIN_WHITELIST: https://ccd-case-management-web-aat.service.core-compute-aat.internal,https://ccd-case-management-web-aat-staging.service.core-compute-aat.internal,https://www-ccd.nonprod.platform.hmcts.net,http://localhost:3451,*
-    PROXY_AGGREGATED: http://ccd-data-store-api-aat.service.core-compute-aat.internal
-    PROXY_CASE_ACTIVITY: http://ccd-case-activity-api-aat.service.core-compute-aat.internal
-    PROXY_DATA: http://ccd-data-store-api-aat.service.core-compute-aat.internal
-    PROXY_DEFINITION_IMPORT: http://ccd-definition-store-api-aat.service.core-compute-aat.internal
-    PROXY_DOCUMENT_MANAGEMENT: http://dm-store-aat.service.core-compute-aat.internal
-    PROXY_PAYMENTS: http://payment-api-aat.service.core-compute-aat.internal
-    PROXY_PRINT_SERVICE: http://ccd-case-print-service-aat.service.core-compute-aat.internal
+  image: ${IMAGE_NAME}
+  ingressHost: ${SERVICE_FQDN}
+

--- a/charts/ccd-api-gateway-web/values.preview.template.yaml
+++ b/charts/ccd-api-gateway-web/values.preview.template.yaml
@@ -1,7 +1,3 @@
 nodejs:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
-  environment:
-    IDAM_OAUTH2_TOKEN_ENDPOINT: https://idam-api.aat.platform.hmcts.net/oauth2/token
-    IDAM_OAUTH2_LOGOUT_ENDPOINT: https://idam-api.aat.platform.hmcts.net/session/:token
-    IDAM_BASE_URL: https://idam-api.aat.platform.hmcts.net

--- a/charts/ccd-api-gateway-web/values.yaml
+++ b/charts/ccd-api-gateway-web/values.yaml
@@ -7,13 +7,22 @@ nodejs:
     CORS_ORIGIN_METHODS: GET,POST,OPTIONS,PUT,DELETE
     IDAM_SERVICE_NAME: ccd_gw
     SECURE_AUTH_COOKIE_ENABLED: true
+
+    IDAM_OAUTH2_TOKEN_ENDPOINT: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/oauth2/token
+    IDAM_OAUTH2_LOGOUT_ENDPOINT: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/session/:token
+    IDAM_BASE_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
+    IDAM_S2S_URL: http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    CORS_ORIGIN_WHITELIST: https://ccd-case-management-web-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal,https://ccd-case-management-web-{{ .Values.global.environment }}-staging.service.core-compute-{{ .Values.global.environment }}.internal,https://www-ccd.nonprod.platform.hmcts.net,http://localhost:3451,*
+    PROXY_AGGREGATED: http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    PROXY_CASE_ACTIVITY: http://ccd-case-activity-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    PROXY_DATA: http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    PROXY_DEFINITION_IMPORT: http://ccd-definition-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    PROXY_DOCUMENT_MANAGEMENT: http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    PROXY_PAYMENTS: http://payment-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
+    PROXY_PRINT_SERVICE: http://ccd-case-print-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
   keyVaults:
     ccd:
-      resourceGroup: ccd-shared
       secrets:
         - ccd-api-gateway-oauth2-client-secret
+        - ccd-gw-s2s-secret
         - postcode-info-address-lookup-token
-    s2s:
-      resourceGroup: rpe-service-auth-provider
-      secrets:
-        - microservicekey-ccd-gw


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RSE-130


### Change description ###
chart-ccd has been fixed for 3.x, since it's changing from an uber chart to parent-sub chart the microservice chart also needs a fix

We need the configurable ingress class change introduced in https://github.com/hmcts/chart-nodejs/releases/tag/v1.8.0

I've bumped the base chart and also did the updates that will be needed to deploy this to environments other than demo and preview

requires https://github.com/hmcts/ccd-shared-infrastructure/pull/42


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
