### PR TITLE
RDM-6215: https-proxy-agent has been deprecated it blocks the build..

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "express": "^4.15.5",
     "form-data": "^2.1.4",
     "http-proxy-middleware": "^0.17.4",
-    "https-proxy-agent": "^2.2.1",
+    "https-proxy-agent": "^2.2.3",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.4",
     "jwt-decode": "^2.2.0",


### PR DESCRIPTION
RDM-6215: https-proxy-agent has been deprecated it blocks the build..

    [RDM-6215] (https://tools.hmcts.net/jira/browse/RDM-6215).