### PR TITLE
Remove default secrets

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -27,3 +27,10 @@ security:
 appInsights:
   enabled: true
   roleName: "ccd-api-gateway"
+secrets:
+  ccd:
+    ccd-api-gateway-oauth2-client-secret:
+    postcode-info-address-lookup-token:
+    microservicekey-ccd-gw:
+    AppInsightsInstrumentationKey:
+    

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -27,9 +27,3 @@ security:
 appInsights:
   enabled: true
   roleName: "ccd-api-gateway"
-secrets:
-  ccd:
-    ccd-api-gateway-oauth2-client-secret: ccd_gateway_secret
-    postcode-info-address-lookup-token: AA
-    microservicekey-ccd-gw: AAAAAAAAAAAAAAAC
-    AppInsightsInstrumentationKey: "some-key"

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -30,7 +30,7 @@ appInsights:
 secrets:
   ccd:
     ccd-api-gateway-oauth2-client-secret: ""
-    postcode-info-address-lookup-token: ""
+    postcode-info-address-lookup-token: AA
     microservicekey-ccd-gw: ""
     AppInsightsInstrumentationKey: ""
     

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -31,10 +31,4 @@ cache:
 appInsights:
   enabled: true
   roleName: "ccd-api-gateway"
-secrets:
-  ccd:
-    ccd-api-gateway-oauth2-client-secret: ""
-    postcode-info-address-lookup-token: AA
-    microservicekey-ccd-gw: ""
-    AppInsightsInstrumentationKey: ""
-    
+

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -29,8 +29,8 @@ appInsights:
   roleName: "ccd-api-gateway"
 secrets:
   ccd:
-    ccd-api-gateway-oauth2-client-secret:
-    postcode-info-address-lookup-token:
-    microservicekey-ccd-gw:
-    AppInsightsInstrumentationKey:
+    ccd-api-gateway-oauth2-client-secret: ""
+    postcode-info-address-lookup-token: ""
+    microservicekey-ccd-gw: ""
+    AppInsightsInstrumentationKey: ""
     

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -2,3 +2,9 @@ appInsights:
   enabled: false
 idam:
   base_url: http://test-idam:1234
+secrets:
+  ccd:
+    ccd-api-gateway-oauth2-client-secret: ccd_gateway_secret
+    postcode-info-address-lookup-token: AA
+    microservicekey-ccd-gw: AAAAAAAAAAAAAAAC
+    AppInsightsInstrumentationKey: "some-key"

--- a/yarn-audit-known-issues
+++ b/yarn-audit-known-issues
@@ -1,5 +1,8 @@
 https://npmjs.com/advisories/1316
-https://npmjs.com/advisories/1324 
+https://npmjs.com/advisories/1324
 https://npmjs.com/advisories/1084
 https://npmjs.com/advisories/1325
 https://npmjs.com/advisories/1179
+
+https://npmjs.com/advisories/1523
+

--- a/yarn-audit-known-issues
+++ b/yarn-audit-known-issues
@@ -3,6 +3,4 @@ https://npmjs.com/advisories/1324
 https://npmjs.com/advisories/1084
 https://npmjs.com/advisories/1325
 https://npmjs.com/advisories/1179
-
 https://npmjs.com/advisories/1523
-


### PR DESCRIPTION
yarn tests fails w/o postcode-info-address-lookup-token if APPINSIGHTS_INSTRUMENTATIONKEY is not mapped the app wont start.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
