### PR TITLE
RDM-8692: Increase UV_THREADPOOL_SIZE to 64

### DIFF
--- a/charts/ccd-api-gateway-web/Chart.yaml
+++ b/charts/ccd-api-gateway-web/Chart.yaml
@@ -2,7 +2,7 @@ description: Helm chart for the HMCTS CCD API Gateway
 apiVersion: v1
 name: ccd-api-gateway-web
 home: https://github.com/hmcts/ccd-api-gateway
-version: 1.0.8
+version: 1.0.9
 maintainers:
   - name: HMCTS CCD Dev Team
     email: ccd-devops@HMCTS.NET

--- a/charts/ccd-api-gateway-web/values.yaml
+++ b/charts/ccd-api-gateway-web/values.yaml
@@ -9,7 +9,7 @@ nodejs:
     CORS_ORIGIN_METHODS: GET,POST,OPTIONS,PUT,DELETE
     IDAM_SERVICE_NAME: ccd_gw
     SECURE_AUTH_COOKIE_ENABLED: true
-
+    UV_THREADPOOL_SIZE: 64
     IDAM_OAUTH2_TOKEN_ENDPOINT: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/oauth2/token
     IDAM_OAUTH2_LOGOUT_ENDPOINT: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/session/:token
     IDAM_BASE_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-8692

### Change description ###

The UV threadpool is used by Node to allow synchronous tasks to be performed asynchronously and not block the main node thread.

Tasks performed by this threadpool include, but are not limited to, DNS resolution - see https://nodejs.org/api/cli.html#cli_uv_threadpool_size_size

This threadpool can become a bottleneck if eg. DNS requests are slow or timeout, leading to requests queueing as they wait for an available worker thread.

Increasing the size of this threadpool is desirable for the traffic profile of api gateway, which typically handles a large number of concurrent IO bound requests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
