### PR TITLE
CCD-2332: Updated project to use Node.js version 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "12.14.1"
+  - "14.18.2"
 cache: yarn
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Keep hub.Dockerfile aligned to this file as far as possible
 
-ARG base=hmctspublic.azurecr.io/base/node:12-alpine
+ARG base=hmctspublic.azurecr.io/base/node:14-alpine
 
 # Base image
 FROM ${base} as base

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ cd ccd-api-gateway
 
 ### Prerequisites
 
-* [Node.js](https://nodejs.org/) >= v12.0.0
+* [Node.js](https://nodejs.org/) >= v14.18.2
 * [yarn](https://yarnpkg.com/)
 * [Docker](https://www.docker.com)
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.4.0",
   "private": true,
   "engines": {
-    "node": ">=12.13.0",
+    "node": "^14.18.2",
     "yarn": "^1.12.3"
   },
   "scripts": {


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2332 (https://tools.hmcts.net/jira/browse/CCD-2332)


### Change description ###
- Updated version of node_js in .travis.yml to 14.18.2
- Updated base in Dockerfile to node:14-alpine
- Updated node version in package.json to ^14.18.2
- Updated Node.js version in README.md to 14.18.2


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
