### PR TITLE
CCD-3302: Fortify Issue 23655017 - Insecure Transport: Weak SSL Protocol - Highest

### DIFF
--- a/server.js
+++ b/server.js
@@ -31,7 +31,8 @@ function createServer(app) {
     const sslDirectory = path.join(__dirname, '..', 'app', 'resources', 'localhost-ssl');
     const sslOptions = {
       cert: fs.readFileSync(path.join(sslDirectory, 'localhost.crt')),
-      key: fs.readFileSync(path.join(sslDirectory, 'localhost.key'))
+      key: fs.readFileSync(path.join(sslDirectory, 'localhost.key')),
+      secureProtocol: "TLS_method"
     };
     return https.createServer(sslOptions, app);
   } else {

--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ function createServer(app) {
     const sslOptions = {
       cert: fs.readFileSync(path.join(sslDirectory, 'localhost.crt')),
       key: fs.readFileSync(path.join(sslDirectory, 'localhost.key')),
-      secureProtocol: "TLS_method"
+      secureProtocol: 'TLS_method'
     };
     return https.createServer(sslOptions, app);
   } else {


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-3302

### Change description ###
Set secureProtocol to "TLS_method" when creating HTTPS server.

Reference documentation :-
- https://www.openssl.org/docs/man1.1.1/man7/ssl.html#Dealing-with-Protocol-Methods
- https://nodejs.org/api/https.html#httpscreateserveroptions-requestlistener
- https://nodejs.org/api/tls.html

Tested locally using :-
```
export ENV=localdev
yarn start
```

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```