### PR TITLE
CCD-4173: Auto-suppress CVEs do not allow empty commit

### DIFF
--- a/.github/workflows/auto-suppress-CVEs.yml
+++ b/.github/workflows/auto-suppress-CVEs.yml
@@ -29,5 +29,4 @@ jobs:
         with:
           skip_dirty_check: true
           commit_message: "Auto-suppress CVEs"
-          commit_options: "--allow-empty"
           branch: master


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-4173

### Change description ###
Auto-suppress CVEs do not allow empty commit.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```