### PR TITLE
Sample activity service to reduce costs

### DIFF
--- a/app/app-insights/app-insights.js
+++ b/app/app-insights/app-insights.js
@@ -3,10 +3,10 @@ const appInsights = require('applicationinsights');
 
 const enabled = config.get('appInsights.enabled');
 
-function fineGrainedSampling(envelope, context) {
+function fineGrainedSampling(envelope) {
   // activity data is not interesting and should not really be going through this proxy anyway
   // when it was at 100% it was generating nearly 50% of HMCTS app insights data ingestion alone
-  if (envelope.data.baseType === 'RequestData' && envelope.data.baseData.name.includes("/activity")) {
+  if (envelope.data.baseType === 'RequestData' && envelope.data.baseData.name.includes('/activity')) {
     envelope.sampleRate = 1;
   }
 

--- a/app/app-insights/app-insights.js
+++ b/app/app-insights/app-insights.js
@@ -3,6 +3,16 @@ const appInsights = require('applicationinsights');
 
 const enabled = config.get('appInsights.enabled');
 
+function fineGrainedSampling(envelope, context) {
+  // activity data is not interesting and should not really be going through this proxy anyway
+  // when it was at 100% it was generating nearly 50% of HMCTS app insights data ingestion alone
+  if (envelope.data.baseType === 'RequestData' && envelope.data.baseData.name.includes("/activity")) {
+    envelope.sampleRate = 1;
+  }
+
+  return true;
+}
+
 const enableAppInsights = () => {
   if (enabled) {
     const appInsightsKey = config.get('secrets.ccd.AppInsightsInstrumentationKey');
@@ -11,6 +21,7 @@ const enableAppInsights = () => {
       .setAutoDependencyCorrelation(true)
       .setAutoCollectConsole(true, true);
     appInsights.defaultClient.context.tags[appInsights.defaultClient.context.keys.cloudRole] = appInsightsRoleName;
+    appInsights.defaultClient.addTelemetryProcessor(fineGrainedSampling);
     appInsights.start();
   }
 };


### PR DESCRIPTION
Nearly 50% of HMCTS's entire Application insights log ingestion appear to be because of activity service

See also https://github.com/hmcts/ccd-case-activity-api/pull/395 for reducing it in the activity service itself

I've tested this locally with an app insights I setup just for this and it's working.
I also logged out the envelope with different URLs:

```
$ curl -H 'Authorization: Bearer 123' localhost:3453/activity/cases/1234/activity
sampleRate: 1
```

```
$ curl -H 'Authorization: Bearer 123' localhost:3453/data/internal/cases/1234
sampleRate: 100
```
