### PR TITLE
Sample remote dependency data as well for activity service

### DIFF
--- a/app/app-insights/app-insights.js
+++ b/app/app-insights/app-insights.js
@@ -6,7 +6,7 @@ const enabled = config.get('appInsights.enabled');
 function fineGrainedSampling(envelope) {
   // activity data is not interesting and should not really be going through this proxy anyway
   // when it was at 100% it was generating nearly 50% of HMCTS app insights data ingestion alone
-  if (envelope.data.baseType === 'RequestData' && envelope.data.baseData.name.includes('/activity')) {
+  if (['RequestData', 'RemoteDependencyData'].includes(envelope.data.baseType) && envelope.data.baseData.name.includes('/activity')) {
     envelope.sampleRate = 1;
   }
 


### PR DESCRIPTION
@banderous noticed that this was happening for dependencies as well. When I tested last time I didn't actually run something on that port, this time I did and could see the data.

This has been tested locally:

```
Envelope {
  ver: 1,
  sampleRate: 1,
  tags: {
    'ai.application.ver': '1.4.0',
    'ai.device.id': '',
    'ai.cloud.roleInstance': '***',
    'ai.device.osVersion': 'Darwin 22.5.0',
    'ai.cloud.role': 'ccd-api-gateway',
    'ai.device.osArchitecture': 'x64',
    'ai.device.osPlatform': 'darwin',
    'ai.internal.sdkVersion': 'node:2.4.2',
    'ai.operation.id': 'bb3f21f9932e4c3da1f89e243bb2196a',
    'ai.operation.name': 'GET /activity/cases/1659733869407088/activity',
    'ai.operation.parentId': '|bb3f21f9932e4c3da1f89e243bb2196a.7bf902cba76045fa.'
  },
  data: Data {
    baseType: 'RemoteDependencyData',
    baseData: RemoteDependencyData {
      ver: 2,
      success: true,
      properties: {},
      measurements: {},
      name: 'GET /cases/1659733869407088/activity',
      data: 'http://localhost:3460/cases/1659733869407088/activity',
```

```
Envelope {
  ver: 1,
  sampleRate: 1,
  tags: {
    'ai.application.ver': '1.4.0',
    'ai.device.id': '',
    'ai.cloud.roleInstance': 'MJ003707',
    'ai.device.osVersion': 'Darwin 22.5.0',
    'ai.cloud.role': 'ccd-api-gateway',
    'ai.device.osArchitecture': 'x64',
    'ai.device.osPlatform': 'darwin',
    'ai.internal.sdkVersion': 'node:2.4.2',
    'ai.location.ip': '127.0.0.1',
    'ai.session.id': '',
    'ai.user.id': '',
    'ai.user.authUserId': '',
    'ai.operation.name': 'GET /activity/cases/1659733869407088/activity',
    'ai.operation.parentId': '3da42ab4f96842999c465684f5df0c77',
    'ai.operation.id': '3da42ab4f96842999c465684f5df0c77'
  },
  data: Data {
    baseType: 'RequestData',
    baseData: RequestData {
      ver: 2,
      properties: {},
      measurements: undefined,
      id: '|3da42ab4f96842999c465684f5df0c77.dc323b4d35a64635.',
      name: 'GET /activity/cases/1659733869407088/activity',
      url: 'http://localhost:3453/activity/cases/1659733869407088/activity',
```