### PR TITLE
CCD-5233: Fix CVE-2022-37614-mockery vulnerability dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "istanbul": "^0.4.5",
     "jsonwebtoken": "^9.0.0",
     "mocha": "^5.2.0",
-    "mockery": "^2.1.0",
     "moment": "^2.29.4",
     "nock": "^13.3.2",
     "pa11y": "^5.2.0",

--- a/test/address/address-lookup.spec.js
+++ b/test/address/address-lookup.spec.js
@@ -1,6 +1,5 @@
 const chai = require('chai');
 const expect = chai.expect;
-const mockery = require('mockery');
 const nock = require('nock');
 
 /* The line below turns off ESLints 'no-undef' for the chai 'fail' function */
@@ -10,11 +9,6 @@ describe('Address Lookup', () => {
   let addressLookup;
 
   before(function(){
-    mockery.enable({
-      warnOnReplace: false,
-      warnOnUnregistered: false,
-      useCleanCache: true
-    });
     addressLookup = require('../../app/address/address-lookup');
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,7 +1144,6 @@ __metadata:
     lodash: ^4.17.21
     mem: ^6.0.0
     mocha: ^5.2.0
-    mockery: ^2.1.0
     moment: ^2.29.4
     nocache: ^2.1.0
     nock: ^13.3.2
@@ -3366,13 +3365,6 @@ __metadata:
     _mocha: ./bin/_mocha
     mocha: ./bin/mocha
   checksum: 08d37a9fa0e67141d8e062356a6915402788fb4d7b1ff9cb7311efa140aa3f255c98f6fa64697981d721d3a41f4eb4d9a28fc986f84499456f1978c0ea2d4109
-  languageName: node
-  linkType: hard
-
-"mockery@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "mockery@npm:2.1.0"
-  checksum: 2454348d891fc8a6f2ff8d60776372461b8a129e1feb2ee19052190add2a28216b91a28c8403040c52ce1e7ec337fb03387f31ecd644af3edcc325ec80da9bcc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-5233

### Change description ###
Fix CVE-2022-37614-mockery vulnerability dependency.
Reference to 'mockery' can safely be removed from ccd-api-gateway. &nbsp; Only used in unit tests to configure warnOnReplace , warnOnUnregistered and useCleanCache.

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```